### PR TITLE
Add geometries in geos:hasGeometry/geos:asWkt to Leaflet map

### DIFF
--- a/src/main/java/org/dvcama/lodview/bean/ResultBean.java
+++ b/src/main/java/org/dvcama/lodview/bean/ResultBean.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class ResultBean {
 
-	private String title, latitude = null, longitude = null, mainIRI = null;
+	private String title, latitude = null, longitude = null, geometry = null, wkt = null, mainIRI = null;
 	private PropertyBean descriptionProperty = null, typeProperty = null;
 	private List<String> images = null, linking = null, videos = null, audios = null;
 	private Map<String, LinkedHashMap<PropertyBean, List<TripleBean>>> literals = new HashMap<String, LinkedHashMap<PropertyBean, List<TripleBean>>>(), resources = new HashMap<String, LinkedHashMap<PropertyBean, List<TripleBean>>>(), bnodes = new HashMap<String, LinkedHashMap<PropertyBean, List<TripleBean>>>();
@@ -91,9 +91,10 @@ public class ResultBean {
 		return literals.get(IRI);
 	}
 
-	public  Map<String, LinkedHashMap<PropertyBean, List<TripleBean>>> getLiterals() {
+	public Map<String, LinkedHashMap<PropertyBean, List<TripleBean>>> getLiterals() {
 		return literals;
 	}
+
 	public LinkedHashMap<PropertyBean, List<TripleBean>> getBnodes(String IRI) {
 		return bnodes.get(IRI);
 	}
@@ -108,6 +109,29 @@ public class ResultBean {
 
 	public String getLatitude() {
 		return latitude;
+	}
+
+	public String getGeometry() {
+		return geometry;
+	}
+
+	public void setGeometry(String geometry) {
+		this.geometry = geometry;
+	}
+
+	public String getWkt() {
+
+		Map<PropertyBean, List<TripleBean>> literals = this.getLiterals(this.geometry);
+		if (literals == null || literals.size() == 0) {
+			return null;
+		}
+		for (PropertyBean key : literals.keySet()) {
+			for (TripleBean tripleBean : literals.get(key)) {
+
+				this.wkt = tripleBean.getValue().toString();
+			}
+		}
+		return wkt;
 	}
 
 	public List<String> getAudios() {
@@ -132,7 +156,10 @@ public class ResultBean {
 
 	@Override
 	public String toString() {
-		return "ResultBean [title=" + title + ", \ndescriptionProperty=" + descriptionProperty + ", \nlatitude=" + latitude + ", \nlongitude=" + longitude + ", \nimages=" + images + ", \nlinking=" + linking + ", \nliterals=" + literals + ", \nresources=" + resources + ", \nbnodes=" + bnodes + "]";
+		return "ResultBean [title=" + title + ", \ndescriptionProperty=" + descriptionProperty + ", \nlatitude="
+				+ latitude + ", \nlongitude=" + longitude + ", \ngeometry=" + geometry + ", \nwkt=" + wkt
+				+ ", \nimages=" + images + ", \nlinking=" + linking + ", \nliterals=" + literals + ", \nresources="
+				+ resources + ", \nbnodes=" + bnodes + "]";
 	}
 
 	public String getMainIRI() {

--- a/src/main/java/org/dvcama/lodview/builder/ResourceBuilder.java
+++ b/src/main/java/org/dvcama/lodview/builder/ResourceBuilder.java
@@ -90,6 +90,8 @@ public class ResourceBuilder {
 				result.setLatitude(tripleBean.getValue());
 			} else if (conf.getLongitudeProperties().contains(tripleBean.getProperty().getNsProperty()) || conf.getLongitudeProperties().contains(tripleBean.getProperty().getProperty())) {
 				result.setLongitude(tripleBean.getValue());
+			} else if (conf.getGeometryProperties().contains(tripleBean.getProperty().getNsProperty()) || conf.getGeometryProperties().contains(tripleBean.getProperty().getProperty())) {
+				result.setGeometry(tripleBean.getValue());
 			} else if (conf.getImageProperties().contains(tripleBean.getProperty().getNsProperty()) || conf.getImageProperties().contains(tripleBean.getProperty().getProperty())) {
 				images.add(tripleBean.getValue());
 			}  else if (conf.getAudioProperties().contains(tripleBean.getProperty().getNsProperty()) || conf.getAudioProperties().contains(tripleBean.getProperty().getProperty())) {

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -43,7 +43,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	private String authPassword = null;
 	private String defaultInverseBehaviour = "collapse";
 
-	private List<String> defaultQueries = null, defaultRawDataQueries = null, defaultInversesQueries = null, defaultInversesTest = null, defaultInversesCountQueries = null, typeProperties = null, audioProperties = null, imageProperties = null, videoProperties = null, linkingProperties = null, titleProperties = null, descriptionProperties = null, longitudeProperties = null, latitudeProperties = null;
+	private List<String> defaultQueries = null, defaultRawDataQueries = null, defaultInversesQueries = null, defaultInversesTest = null, defaultInversesCountQueries = null, typeProperties = null, audioProperties = null, imageProperties = null, videoProperties = null, linkingProperties = null, titleProperties = null, descriptionProperties = null, longitudeProperties = null, latitudeProperties = null, geometryProperties = null;
 	private List<String> colorPair = null, skipDomains = null, mainOntologiesPrefixes = null;
 	private Map<String, String> colorPairMatcher = null;
 
@@ -96,6 +96,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 		linkingProperties = getMultiConfValue("linkingProperties");
 		longitudeProperties = getMultiConfValue("longitudeProperties");
 		latitudeProperties = getMultiConfValue("latitudeProperties");
+		geometryProperties = getMultiConfValue("geometryProperties");
 
 		defaultQueries = getMultiConfValue("defaultQueries");
 		defaultRawDataQueries = getMultiConfValue("defaultRawDataQueries");
@@ -251,6 +252,10 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 		return latitudeProperties;
 	}
 
+	public List<String> getGeometryProperties() {
+		return geometryProperties;
+	}
+
 	public List<String> getDescriptionProperties() {
 		return descriptionProperties;
 	}
@@ -316,7 +321,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	@Override
 	public String toString() {
 		return "ConfigurationBean [confModel=" + confModel + ", context=" + context + ", confFile=" + confFile + ", endPointUrl=" + endPointUrl + ", IRInamespace=" + IRInamespace + ", contentEncoding=" + contentEncoding + ", staticResourceURL=" + staticResourceURL + ", preferredLanguage=" + preferredLanguage + ", publicUrlPrefix=" + publicUrlPrefix + ", authUsername=" + authUsername + ", authPassword=" + authPassword + ", defaultInverseBehaviour=" + defaultInverseBehaviour + ", defaultQueries=" + defaultQueries + ", defaultRawDataQueries=" + defaultRawDataQueries + ", defaultInversesQueries=" + defaultInversesQueries + ", defaultInversesTest=" + defaultInversesTest + ", defaultInversesCountQueries=" + defaultInversesCountQueries + ", typeProperties=" + typeProperties
-				+ ", imageProperties=" + imageProperties + ", audioProperties=" + audioProperties + ", videoProperties=" + videoProperties + ", linkingProperties=" + linkingProperties + ", titleProperties=" + titleProperties + ", descriptionProperties=" + descriptionProperties + ", longitudeProperties=" + longitudeProperties + ", latitudeProperties=" + latitudeProperties + ", colorPair=" + colorPair + ", skipDomains=" + skipDomains + ", rand=" + rand + "]";
+				+ ", imageProperties=" + imageProperties + ", audioProperties=" + audioProperties + ", videoProperties=" + videoProperties + ", linkingProperties=" + linkingProperties + ", titleProperties=" + titleProperties + ", descriptionProperties=" + descriptionProperties + ", longitudeProperties=" + longitudeProperties + ", latitudeProperties=" + latitudeProperties + ", geometryProperties=" + geometryProperties + ", colorPair=" + colorPair + ", skipDomains=" + skipDomains + ", rand=" + rand + "]";
 	}
 
 	public String getHomeUrl() {

--- a/src/main/java/org/dvcama/lodview/controllers/LodController.java
+++ b/src/main/java/org/dvcama/lodview/controllers/LodController.java
@@ -96,6 +96,8 @@ public class LodController {
 			result.append("<links tot=\"" + results.getLinking().size() + "\"/>");
 			result.append("<longitude><![CDATA[" + results.getLongitude() + "]]></longitude>");
 			result.append("<latitude><![CDATA[" + results.getLatitude() + "]]></latitude>");
+			result.append("<geometry><![CDATA[" + results.getGeometry() + "]]></geometry>");
+			result.append("<wkt><![CDATA[" + results.getWkt() + "]]></wkt>");
 
 			result.append("</root>");
 			return result.toString();

--- a/src/main/webapp/WEB-INF/conf.ttl
+++ b/src/main/webapp/WEB-INF/conf.ttl
@@ -9,6 +9,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix geos: <http://www.opengis.net/ont/geosparql#> .
 @prefix ocd: <http://dati.camera.it/ocd/> . 
 @prefix units: <http://dbpedia.org/units/> .
 @prefix geonames: <http://www.geonames.org/ontology#> .  
@@ -188,6 +189,7 @@
 								
 	conf:longitudeProperties	geo:long;
 	conf:latitudeProperties		geo:lat;
+	conf:geometryProperties		geos:hasGeometry;
 	conf:linkingProperties		owl:sameAs , skos:exactMatch , gn:locatedIn ,  <http://www.bbc.co.uk/ontologies/coreconcepts/sameAs>;
 
 	conf:videoProperties		<http://schema.org/VideoObject>;

--- a/src/main/webapp/WEB-INF/views/inc/header.jsp
+++ b/src/main/webapp/WEB-INF/views/inc/header.jsp
@@ -17,6 +17,8 @@
 <!-- managing maps  -->
 <link rel="stylesheet" href="${conf.getStaticResourceURL()}vendor/leaflet/leaflet.css" />
 <script src="${conf.getStaticResourceURL()}vendor/leaflet/leaflet.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wicket/1.3.5/wicket.min.js" integrity="sha256-G9R/Zo79niGI6NHqBvRelhjBRCY4N5rtR73N4WCIbkQ=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/wicket/1.3.5/wicket-leaflet.min.js" integrity="sha256-vI4mtnrisBvi+wZUx+emAuyJQmBI5AoVcGL/1f8Dt3s=" crossorigin="anonymous"></script>
 <link rel="canonical" href="${results.getMainIRI()}" >
 <script src="${conf.getStaticResourceURL()}vendor/masonry.pkgd.min.js"></script>
 <script src="${conf.getStaticResourceURL()}vendor/modernizr-custom.min.js"></script>
@@ -48,7 +50,7 @@ div#loadPanel span.ok img {
 	var isRetina = window.devicePixelRatio > 1;
 	var isChrome = /chrom(e|ium)/.test(navigator.userAgent.toLowerCase())
 </script>
-<c:set var="hasMap" scope="page" value='${results.getLatitude()!=null && !results.getLatitude().equals("") && results.getLongitude()!=null&&!results.getLongitude().equals("")}'></c:set>
+<c:set var="hasMap" scope="page" value='${(results.getLatitude()!=null && !results.getLatitude().equals("") && results.getLongitude()!=null && !results.getLongitude().equals("")) || (results.getGeometry()!=null && !results.getGeometry().equals(""))}'></c:set>
 <c:set var="hasLod" scope="page" value="${results.getLinking()!=null && results.getLinking().size()>0}"></c:set>
 <c:set var="hasImages" scope="page" value="${results.getImages()!=null && results.getImages().size()>0}"></c:set>
 <c:set var="hasVideos" scope="page" value="${results.getVideos()!=null && results.getVideos().size()>0}"></c:set>


### PR DESCRIPTION
Uses the Wicket library (https://github.com/arthur-e/Wicket) to parse the values of geos/hasGeometry/geos:asWkt triples. Geometries are added to the leaflet map that is now used to display lat/long points. 